### PR TITLE
Use non-deprecated testPathPatterns option for jest

### DIFF
--- a/packages/node-postgres/example/package.json
+++ b/packages/node-postgres/example/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathPattern='test/smoke.test.ts' --runInBand --detectOpenHandles --forceExit"
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathPatterns='test/smoke.test.ts' --runInBand --detectOpenHandles --forceExit"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/postgres-js/example/package.json
+++ b/packages/postgres-js/example/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathPattern='test/smoke.test.js' --runInBand --detectOpenHandles --forceExit"
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathPatterns='test/smoke.test.js' --runInBand --detectOpenHandles --forceExit"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
#99 and #104 bump `jest` to a newer version for the 2 example projects. The older `--testPathPattern` flag is no longer available in the newer version, so this PR uses the replacement which has an `s` on the end. The behavior is the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
