### PR TITLE
Bump versions from 0.1.1 to 0.1.2

### DIFF
--- a/packages/node-postgres/package-lock.json
+++ b/packages/node-postgres/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/aurora-dsql-node-postgres-connector",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.894.0",

--- a/packages/node-postgres/package.json
+++ b/packages/node-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An AWS Aurora DSQL connector with IAM authentication for node-postgres",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/postgres-js/package-lock.json
+++ b/packages/postgres-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/aurora-dsql-postgresjs-connector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/aurora-dsql-postgresjs-connector",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.901.0",

--- a/packages/postgres-js/package.json
+++ b/packages/postgres-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-postgresjs-connector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An AWS Aurora DSQL connector with IAM authentication for Postgres.js",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR bumps the package versions for `@aws/aurora-dsql-node-postgres-connector` and `@aws/aurora-dsql-postgresjs-connector` from `0.1.1` to `0.1.2`.

This is in preparation for a release, given the recent changes. The changes are backwards compatible, with the biggest one being modifying the build to publish CommonJS modules for both packages. Otherwise the only changes are version upgrades.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
