### PR TITLE
parse from connectionString, check if region is set before parsing fr…

### DIFF
--- a/packages/node-postgres/src/aurora-dsql-util.ts
+++ b/packages/node-postgres/src/aurora-dsql-util.ts
@@ -79,7 +79,7 @@ export class AuroraDSQLUtil {
     if (typeof config === "string") {
       dsqlConfig = parse(config) as AuroraDSQLConfig;
     } else if (config.connectionString) {
-      // parse the connectionString 
+      // connection string properties override as set by upstream library
       dsqlConfig = Object.assign({}, config, parse(config.connectionString));
     } else {
       dsqlConfig = config;

--- a/packages/node-postgres/test/aurora-dsql-util.test.ts
+++ b/packages/node-postgres/test/aurora-dsql-util.test.ts
@@ -207,6 +207,23 @@ describe("AuroraDSQLUtil", () => {
       expect(result.host).toBe("cluster.dsql.us-east-1.on.aws");
     });
 
+    it("should override config values with connectionString values", () => {
+      const config = {
+        host: "config-host.dsql.us-west-2.on.aws",
+        user: "config-user",
+        database: "config-db",
+        connectionString:
+          "postgresql://connstr-user@connstr-host.dsql.us-east-1.on.aws:5432/connstr-db",
+      };
+
+      const result = AuroraDSQLUtil.parsePgConfig(config);
+
+      expect(result.host).toBe("connstr-host.dsql.us-east-1.on.aws");
+      expect(result.user).toBe("connstr-user");
+      expect(result.database).toBe("connstr-db");
+      expect(result.region).toBe("us-east-1");
+    });
+
     it("should build hostname from clusterId and region from config", () => {
       const config = {
         host: "cluster123",


### PR DESCRIPTION
*Description of changes:*
- parse from connectionString within the config object 
- check if region is set before region is parse from host

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
