### PR TITLE
Fix node-postgres workflow permissions

### DIFF
--- a/.github/workflows/node-postgres-integration-tests.yml
+++ b/.github/workflows/node-postgres-integration-tests.yml
@@ -38,7 +38,6 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write # required by aws-actions/configure-aws-credentials
     strategy:
       max-parallel: 1

--- a/.github/workflows/node-postgres-publish.yml
+++ b/.github/workflows/node-postgres-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     if: startsWith(github.event.release.tag_name, 'aurora-dsql-node-postgres-connector-v')
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
     uses: ./.github/workflows/node-postgres-integration-tests.yml
     secrets: inherit
 


### PR DESCRIPTION
This PR fixes #114 which didn't account for the shared permissions required by the integration tests which are invoked from the publish workflow.

It fixes the following error:

```
The workflow is not valid. .github/workflows/node-postgres-publish.yml (Line: 8, Col: 3): Error calling workflow 'awslabs/aurora-dsql-nodejs-connector/.github/workflows/node-postgres-integration-tests.yml@0a0d9ea75d3f5629945fd4df7705506792dddf19'. The nested job 'run-tests' is requesting 'contents: read, id-token: write', but is only allowed 'contents: none, id-token: none'.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
