### PR TITLE
Set up trusted publishing for Postgres.js

### DIFF
--- a/.github/workflows/postgres-js-integration-tests.yml
+++ b/.github/workflows/postgres-js-integration-tests.yml
@@ -38,7 +38,6 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write # required by aws-actions/configure-aws-credentials
     strategy:
       max-parallel: 1

--- a/.github/workflows/postgres-js-publish.yml
+++ b/.github/workflows/postgres-js-publish.yml
@@ -1,7 +1,5 @@
 name: Publish Aurora DSQL Connector for Postgres.js
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 on:
   release:
     types: [published]
@@ -9,6 +7,8 @@ on:
 jobs:
   test:
     if: startsWith(github.event.release.tag_name, 'aurora-dsql-postgresjs-connector-v')
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
     uses: ./.github/workflows/postgres-js-integration-tests.yml
     secrets: inherit
 
@@ -16,12 +16,15 @@ jobs:
     needs: test
     if: startsWith(github.event.release.tag_name, 'aurora-dsql-postgresjs-connector-v')
     runs-on: ubuntu-latest
+    environment: NPM
+    permissions:
+      id-token: write # required for trusted publishing
     steps:
       - uses: actions/checkout@v4
       
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '25' # must be new enough so NPM supports trusted publishing
           registry-url: 'https://registry.npmjs.org'
       
       - run: |
@@ -31,5 +34,3 @@ jobs:
       
       - run: npm publish --provenance
         working-directory: packages/postgres-js
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
As with #114, this PR enables NPM trusted publishing for the Postgres.js connector package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
