### PR TITLE
Bump node-postgres from 0.1.2 to 0.1.3

### DIFF
--- a/packages/node-postgres/package-lock.json
+++ b/packages/node-postgres/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/aurora-dsql-node-postgres-connector",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.894.0",

--- a/packages/node-postgres/package.json
+++ b/packages/node-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "An AWS Aurora DSQL connector with IAM authentication for node-postgres",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR bumps the node-postgres version in preparation for release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
