### PR TITLE
Allow CI/CD workflows to run in parallel without conflicts

### DIFF
--- a/.github/workflows/dsql-cluster-create.yml
+++ b/.github/workflows/dsql-cluster-create.yml
@@ -75,3 +75,16 @@ jobs:
             echo "cluster-endpoint=${CLUSTER_ID}.dsql.${{ env.AWS_REGION }}.on.aws"
             echo "region=${{ env.AWS_REGION }}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Create non-admin role
+        env:
+          NON_ADMIN_USER: "testuser"
+          CLUSTER_ENDPOINT: ${{ steps.create.outputs.cluster-endpoint }}
+        run: |
+          export PGHOST="$CLUSTER_ENDPOINT"
+          export PGUSER="admin"
+          export PGPASSWORD=$(aws dsql generate-db-connect-admin-auth-token --hostname "$CLUSTER_ENDPOINT" --region "${{ env.AWS_REGION }}" --expires-in 300)
+          export PGSSLMODE="require"
+
+          psql -c "CREATE ROLE \"$NON_ADMIN_USER\" WITH LOGIN"
+          psql -c "AWS IAM GRANT \"$NON_ADMIN_USER\" TO '${{ secrets.AWS_IAM_ROLE }}'"

--- a/.github/workflows/dsql-cluster-create.yml
+++ b/.github/workflows/dsql-cluster-create.yml
@@ -84,6 +84,7 @@ jobs:
           export PGHOST="$CLUSTER_ENDPOINT"
           export PGUSER="admin"
           export PGPASSWORD=$(aws dsql generate-db-connect-admin-auth-token --hostname "$CLUSTER_ENDPOINT" --region "${{ env.AWS_REGION }}" --expires-in 300)
+          export PGDATABASE="postgres"
           export PGSSLMODE="require"
 
           psql -c "CREATE ROLE \"$NON_ADMIN_USER\" WITH LOGIN"

--- a/.github/workflows/dsql-cluster-create.yml
+++ b/.github/workflows/dsql-cluster-create.yml
@@ -1,0 +1,77 @@
+name: Create Aurora DSQL Cluster
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        required: true
+        type: string
+        description: "Name of the calling workflow (used for cluster naming)"
+    secrets:
+      AWS_IAM_ROLE:
+        required: true
+    outputs:
+      cluster-id:
+        description: "The cluster identifier"
+        value: ${{ jobs.create.outputs.cluster-id }}
+      cluster-endpoint:
+        description: "The cluster endpoint"
+        value: ${{ jobs.create.outputs.cluster-endpoint }}
+      region:
+        description: "The AWS region"
+        value: ${{ jobs.create.outputs.region }}
+
+env:
+  AWS_REGION: us-east-1
+  MAX_RETRIES: 5
+  INITIAL_BACKOFF: 10
+
+jobs:
+  create:
+    name: Create Aurora DSQL Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+    outputs:
+      cluster-id: ${{ steps.create.outputs.cluster-id }}
+      cluster-endpoint: ${{ steps.create.outputs.cluster-endpoint }}
+      region: ${{ steps.create.outputs.region }}
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create cluster
+        id: create
+        run: |
+          CLUSTER_NAME="${{ inputs.workflow_name }}-${{ github.run_id }}"
+
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            RESULT=$(aws dsql create-cluster \
+              --no-deletion-protection-enabled \
+              --tags "Name=$CLUSTER_NAME,Repo=${{ github.repository }},Type=integration-test" 2>&1) && break
+            BACKOFF=$((INITIAL_BACKOFF * attempt))
+            echo "Attempt $attempt failed, retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+
+          CLUSTER_ID=$(echo "$RESULT" | jq -r '.identifier')
+          if [ -z "$CLUSTER_ID" ] || [ "$CLUSTER_ID" = "null" ]; then
+            echo "Failed to create cluster: $RESULT"
+            exit 1
+          fi
+
+          echo "Waiting for cluster $CLUSTER_ID to become active..."
+          aws dsql wait cluster-active --identifier "$CLUSTER_ID"
+
+          {
+            echo "cluster-id=$CLUSTER_ID"
+            echo "cluster-endpoint=${CLUSTER_ID}.dsql.${{ env.AWS_REGION }}.on.aws"
+            echo "region=${{ env.AWS_REGION }}"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dsql-cluster-delete.yml
+++ b/.github/workflows/dsql-cluster-delete.yml
@@ -1,0 +1,38 @@
+name: Delete Aurora DSQL Cluster
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      cluster-id:
+        required: true
+        type: string
+        description: "The cluster identifier to delete"
+      region:
+        required: true
+        type: string
+        description: "The AWS region where the cluster exists"
+    secrets:
+      AWS_IAM_ROLE:
+        required: true
+
+jobs:
+  delete:
+    name: Delete Aurora DSQL Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ inputs.region }}
+
+      - name: Delete cluster
+        run: |
+          echo "Deleting cluster ${{ inputs.cluster-id }}..."
+          aws dsql delete-cluster --identifier "${{ inputs.cluster-id }}" > /dev/null

--- a/.github/workflows/node-postgres-integration-tests.yml
+++ b/.github/workflows/node-postgres-integration-tests.yml
@@ -15,11 +15,6 @@ on:
       - ".github/workflows/node-postgres-integration-tests.yml"
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
-    inputs:
-      tags:
-        description: "Manual Workflow Run"
-        required: false
-        type: string
   workflow_call:
 
 jobs:
@@ -33,9 +28,18 @@ jobs:
       - id: versions
         run: echo "matrix=[20, 22, 24]" >> $GITHUB_OUTPUT
 
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: node-postgres-tests
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
   run-tests:
     name: Node-postgres tests
-    needs: [setup]
+    needs: [setup, create-cluster]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
@@ -58,13 +62,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
-          aws-region: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          aws-region: ${{ needs.create-cluster.outputs.region }}
 
       - name: Run tests
         working-directory: ./packages/node-postgres
         env:
-          CLUSTER_ENDPOINT: ${{ secrets.AURORA_DSQL_INTEGRATION_NODE_POSTGRES_CLUSTER_EDNPOINT }}
-          REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
           IAM_ROLE: $${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
         run: |
           npm ci
@@ -74,9 +78,9 @@ jobs:
       - name: Run example smoke test
         working-directory: ./packages/node-postgres
         env:
-          CLUSTER_ENDPOINT: ${{ secrets.AURORA_DSQL_INTEGRATION_NODE_POSTGRES_CLUSTER_EDNPOINT }}
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           CLUSTER_USER: admin
-          REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
         run: |
           npm run build:prod
           npm link
@@ -84,3 +88,15 @@ jobs:
           npm ci
           npm link @aws/aurora-dsql-node-postgres-connector
           npm run test
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, run-tests]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials

--- a/.github/workflows/postgres-js-integration-tests.yml
+++ b/.github/workflows/postgres-js-integration-tests.yml
@@ -15,11 +15,6 @@ on:
       - ".github/workflows/postgres-js-integration-tests.yml"
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
-    inputs:
-      tags:
-        description: 'Manual Workflow Run'
-        required: false
-        type: string
   workflow_call:
 
 jobs:
@@ -33,9 +28,18 @@ jobs:
       - id: versions
         run: echo "matrix=[20, 22, 24]" >> $GITHUB_OUTPUT
 
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: postgres-js-tests
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
   run-tests:
     name: Postgres.js tests
-    needs: [setup]
+    needs: [setup, create-cluster]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
@@ -58,13 +62,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
-          aws-region: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          aws-region: ${{ needs.create-cluster.outputs.region }}
 
       - name: Run tests
         working-directory: ./packages/postgres-js
         env:
-          CLUSTER_ENDPOINT: ${{ secrets.AURORA_DSQL_INTEGRATION_POSTGRESJS_CLUSTER_EDNPOINT }}
-          REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
           IAM_ROLE: $${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
         run: |
           npm ci
@@ -74,9 +78,9 @@ jobs:
       - name: Run example smoke test
         working-directory: ./packages/postgres-js
         env:
-          CLUSTER_ENDPOINT: ${{ secrets.AURORA_DSQL_INTEGRATION_POSTGRESJS_CLUSTER_EDNPOINT }}
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           CLUSTER_USER: admin
-          REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
         run: |
           npm run build:prod
           npm link
@@ -89,9 +93,9 @@ jobs:
         if: matrix.node-version != 20 # Websocket is not available by default until node 21 and above
         working-directory: ./packages/postgres-js
         env:
-          CLUSTER_ENDPOINT: ${{ secrets.AURORA_DSQL_INTEGRATION_POSTGRESJS_CLUSTER_EDNPOINT }}
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           CLUSTER_USER: admin
-          REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
           CONNECTION_CHECK: true
         run: |
           npm ci
@@ -102,11 +106,23 @@ jobs:
         if: matrix.node-version != 20 # Websocket is not available by default until node 21 and above
         working-directory: ./packages/postgres-js
         env:
-          CLUSTER_ENDPOINT: ${{ secrets.AURORA_DSQL_INTEGRATION_POSTGRESJS_CLUSTER_EDNPOINT }}
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           CLUSTER_USER: admin
-          REGION: ${{ secrets.AURORA_DSQL_INTEGRATION_CLUSTER_REGION }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
           CONNECTION_CHECK: false
         run: |
           npm ci
           npm run build:prod 
           node test/community/index.js
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, run-tests]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.AURORA_DSQL_NODEJS_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials


### PR DESCRIPTION
This PR modifies the CI/CD workflows to create a cluster per workflow, which prevents conflicts between parallel runs.

This prevents frustrating behavior where GitHub cancels pending workflows when multiple PRs are being created or worked on at the same time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
